### PR TITLE
Fixed port for spotDL docker-compose

### DIFF
--- a/Apps/spot-dl/docker-compose.yml
+++ b/Apps/spot-dl/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: spotdl/spotify-downloader:v4.2.5
     restart: unless-stopped
     ports:
-      - target: 8808
-        published: 8808
+      - target: 8800
+        published: 8800
         protocol: tcp
     volumes:
       - type: bind
@@ -19,7 +19,7 @@ services:
       - '--host'
       - 0.0.0.0
       - '--port'
-      - '8808'
+      - '8800'
       - '--web-use-output-dir'
     tty: true
 x-casaos:
@@ -42,4 +42,4 @@ x-casaos:
       en_us: |
         The default download location is set to `/DATA/Media/Music`. You can change this by going into the app settings and changing the specified path.
   category: Coolstore
-  port_map: '8808'
+  port_map: '8800'


### PR DESCRIPTION
This should solve issue #60. As noted by issue https://github.com/spotDL/spotify-downloader/issues/2035 of the original project, at the moment there seems sto be an issue with the port used by the container, as  when looking for songs it (wrongly) connects to port 8800 regardless of the port specified. A user suggested changing the port to 8800, and it does indeed fix the issue.