### PR TITLE
[SpotDL] Update config mount target to /root/.spotdl

### DIFF
--- a/Apps/spot-dl/docker-compose.yml
+++ b/Apps/spot-dl/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         target: /music
       - type: bind
         source: /DATA/AppData/coolstore-spotdl/config
-        target: /config
+        target: /root/.spotdl
     command:
       - web
       - '--host'


### PR DESCRIPTION
### Description
Updated the config volume mount in `docker-compose.yml` to use `/root/.spotdl` as the target directory.

### Reason for Change:
SpotDL expects its configuration (`config.json`) in `/root/.spotdl`. This change ensures CasaOS can access the config from the Files app.

The app developer does not plan to support changing the default config directory ([issue #2180](https://github.com/spotDL/spotify-downloader/issues/2180)).

### Impact:
- User settings, credentials, and generated configs will persist across container restarts.
- No changes are required to commands or scripts inside the container.